### PR TITLE
Update EasyXT.java to solve issue with filter on intensities

### DIFF
--- a/src/main/java/ch/epfl/biop/imaris/EasyXT.java
+++ b/src/main/java/ch/epfl/biop/imaris/EasyXT.java
@@ -2257,7 +2257,7 @@ public class EasyXT {
             // current @EasyXT.Stats.export() table are string
             // Issue with using imagej= 1.53j ? , to getColumnAsStrings() )
             // workaround use Variable[]
-            ResultsTable rt = Stats.export(aItem, columnName);
+            ResultsTable rt = Stats.export(aItem);
 
             double[] ids = Arrays.stream(rt.getColumnAsVariables("ID")).map(var -> var.getValue()).mapToDouble(d -> d).toArray();
             double[] values = Arrays.stream(rt.getColumnAsVariables(columnName)).map(var -> var.getValue()).mapToDouble(d -> d).toArray();


### PR DESCRIPTION
removes column name in Stats.export() within filter() so one can filter on "Intensity Mean" and specify Channel number